### PR TITLE
Add authorization header

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         java-version: 14
     - name: Build with Gradle
-      run: ./gradlew run -Dorg.gradle.daemon=false
+      run: ./gradlew run -Dorg.gradle.daemon=false -Dgithubtoken="Bearer ${{ secrets.GITHUB_TOKEN }}"
     - name: Push changes
       run: |
         git config --global user.email "cli@github.com"
@@ -29,4 +29,4 @@ jobs:
         git add icons/*
         git commit --allow-empty -m "[auto-update]"
         git push https://Anuken:${{ secrets.API_TOKEN_GITHUB }}@github.com/Anuken/MindustryMods
-      
+

--- a/build.gradle
+++ b/build.gradle
@@ -21,4 +21,5 @@ task run(dependsOn: classes, type: JavaExec){
     main = "modupdater.ModUpdater"
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
+    systemProperties System.properties
 }

--- a/src/modupdater/ModUpdater.java
+++ b/src/modupdater/ModUpdater.java
@@ -26,6 +26,8 @@ public class ModUpdater{
     static final ObjectSet<String> blacklist = ObjectSet.with("Snow-of-Spirit-Fox-Mori/old-mod", "TheSaus/Cumdustry", "Anuken/ExampleMod", "Anuken/ExampleJavaMod", "Anuken/ExampleKotlinMod", "Mesokrix/Vanilla-Upgraded", "o7-Fire/Mindustry-Ozone");
     static final int iconSize = 64;
 
+    static final String githubToken = OS.prop("githubtoken");
+
     public static void main(String[] args){
         Core.net = makeNet();
         new ModUpdater();
@@ -189,6 +191,7 @@ public class ModUpdater{
         Core.net.http(new HttpRequest()
             .timeout(10000)
             .method(HttpMethod.GET)
+            .header("authorization", githubToken)
             .header("accept", "application/vnd.github.baptiste-preview+json")
             .url(api + url + (params == null ? "" : "?" + params.keys().toSeq().map(entry -> Strings.encode(entry) + "=" + Strings.encode(params.get(entry))).toString("&"))), response -> {
             Log.info("&lcSending search query. Status: @; Queries remaining: @/@", response.getStatus(), response.getHeader("X-RateLimit-Remaining"), response.getHeader("X-RateLimit-Limit"));


### PR DESCRIPTION
This will allow you to send **30** requests instead of **10**.
Based on: 
https://docs.github.com/en/actions/reference/authentication-in-a-workflow
https://docs.github.com/en/rest/reference/search#rate-limit