### PR TITLE
Set hasScripts of my mod to false

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -5359,7 +5359,7 @@
     "lastUpdated": "2024-06-21T17:23:35Z",
     "stars": 2,
     "minGameVersion": "144.3",
-    "hasScripts": true,
+    "hasScripts": false,
     "hasJava": false,
     "description": "\nMakes the game multiple times harder by nerfing anything that was remotely good into oblivion\nand using various methods to prevent schematics from working and generally make processing harder\n"
   },


### PR DESCRIPTION
Happened to have a JavaScript file in my report for testing(because I didn't realize that iOS didn't support JS) right as the comber found my mod and now it cant test it on my iphone